### PR TITLE
Makefile.in: Fix typo of ($LIB) instead of $(LIB).

### DIFF
--- a/Source/SWILL/Makefile.in
+++ b/Source/SWILL/Makefile.in
@@ -44,7 +44,7 @@ $(SLIB): $(LIBOBJS)
 	$(AR) cr $(SLIB) $(LIBOBJS) $(DOHOBJS)
 	cp -f $(SLIB) ../..
 
-($LIB): $(LIBOBJS)
+$(LIB): $(LIBOBJS)
 	@echo "Building shared library"
 	$(LDSHARED) $(LIBOBJS) $(DOHOBJS) -o $(LIB) $(NETLIBS)
 	cp -f $(LIB) ../..


### PR DESCRIPTION
Stops make(1) exiting with an error.